### PR TITLE
Add script tests and bump req for `qbraid-core` to `0.1.37`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test Python Scripts
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, reopened, ready_for_review, synchronize]
+  push:
+    branches: [ main ]
+
+jobs:
+  format-test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-mock black isort
+          pip install -r requirements.txt
+
+      - name: Check code formatting with black
+        run: |
+          black --check src/ tests/
+
+      - name: Check imports with isort
+        run: |
+          isort --check-only --profile black src/ tests/
+
+      - name: Run tests
+        run: |
+          pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,172 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# VS Code
+.vscode/
+*.code-workspace
+
+# Mac OS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# qBraid specific (if any)
+.qbraid/
+*.qbraid.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qBraid Publish Environment Action
+# <img src="icon.png" height=60px align='center'> qBraid Publish Environment Action
 
 GitHub Action to create and request to publish a new environment on qBraid.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+import os
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def mock_environment_config():
+    """Fixture for a mock environment configuration."""
+    return Mock(name="Test Environment")
+
+
+@pytest.fixture
+def setup_env_vars():
+    """Setup test environment variables and clean them up after test."""
+    # Save original environment variables
+    original_env = os.environ.copy()
+
+    # Set test environment variables
+    os.environ["ENV_CONFIG_PATH"] = "path/to/test/config.yaml"
+    os.environ["PERSIST_ENV"] = "false"
+    os.environ["GITHUB_ENV"] = "path/to/github/env"
+    os.environ["ENV_SLUG"] = "test-env-slug"
+
+    yield
+
+    # Restore original environment variables
+    os.environ.clear()
+    os.environ.update(original_env)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-qbraid-core[environments]>=0.1.36
+qbraid-core[environments]>=0.1.37

--- a/src/remote_publish.py
+++ b/src/remote_publish.py
@@ -45,7 +45,9 @@ def publish_environment(config: EnvironmentConfig, persist_env: bool) -> str:
     """Publishes the environment and retrieves the environment slug."""
     try:
         client = EnvironmentManagerClient()
-        response = client.remote_publish_environment(config=config, persist_env=persist_env)
+        response = client.remote_publish_environment(
+            config=config, persist_env=persist_env
+        )
         env_slug = response["envSlug"]
         print("Request validated. Initializing environment creation process...")
         print(f"Environment slug: {env_slug}")

--- a/src/wait_for_completion.py
+++ b/src/wait_for_completion.py
@@ -22,12 +22,18 @@ import sys
 from qbraid_core.services.environments.client import EnvironmentManagerClient
 
 
-def wait_for_environment_publish(client: EnvironmentManagerClient, env_slug: str) -> bool:
+def wait_for_environment_publish(
+    client: EnvironmentManagerClient, env_slug: str
+) -> bool:
     """Waits for the environment to be published and returns the exit code."""
     try:
-        print(f"Waiting for publishing process to complete for environment: {env_slug}...")
+        print(
+            f"Waiting for publishing process to complete for environment: {env_slug}..."
+        )
         success = client.wait_for_env_remote_publish(env_slug)
-        print(f"Publish environment process {'completed successfully' if success else 'failed'}")
+        print(
+            f"Publish environment process {'completed successfully' if success else 'failed'}"
+        )
         return success
     except Exception as e:
         print(f"Error in environment publish request: \n\t{e}")

--- a/tests/test_remote_publish.py
+++ b/tests/test_remote_publish.py
@@ -1,0 +1,139 @@
+import os
+import sys
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+# Add src directory to path to import modules
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.remote_publish import (
+    load_environment_config,
+    main,
+    publish_environment,
+    write_slug_to_github_env,
+)
+
+
+class TestRemotePublish:
+
+    @patch("os.path.exists", return_value=True)
+    @patch("src.remote_publish.EnvironmentConfig")
+    def test_load_environment_config_success(self, mock_env_config, mock_exists):
+        # Arrange
+        config_path = "path/to/config.yaml"
+        mock_config = MagicMock()
+        mock_env_config.from_yaml.return_value = mock_config
+
+        # Act
+        result = load_environment_config(config_path)
+
+        # Assert
+        mock_exists.assert_called_with(config_path)
+        mock_env_config.from_yaml.assert_called_with(config_path)
+        assert result == mock_config
+
+    @patch("os.path.exists", return_value=False)
+    def test_load_environment_config_file_not_found(self, mock_exists, capfd):
+        # Arrange
+        config_path = "path/to/nonexistent/config.yaml"
+
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            load_environment_config(config_path)
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert f"Environment configuration file not found at {config_path}" in out
+
+    @patch(
+        "src.remote_publish.EnvironmentConfig.from_yaml",
+        side_effect=Exception("Test error"),
+    )
+    @patch("os.path.exists", return_value=True)
+    def test_load_environment_config_invalid_yaml(
+        self, mock_exists, mock_from_yaml, capfd
+    ):
+        # Arrange
+        config_path = "path/to/invalid/config.yaml"
+
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            load_environment_config(config_path)
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert "Failed to load environment configuration" in out
+        assert "Test error" in out
+
+    @patch("src.remote_publish.EnvironmentManagerClient")
+    def test_publish_environment_success(self, mock_client_cls):
+        # Arrange
+        mock_config = MagicMock()
+        mock_client = mock_client_cls.return_value
+        mock_client.remote_publish_environment.return_value = {"envSlug": "test-slug"}
+
+        # Act
+        result = publish_environment(mock_config, False)
+
+        # Assert
+        mock_client.remote_publish_environment.assert_called_with(
+            config=mock_config, persist_env=False
+        )
+        assert result == "test-slug"
+
+    @patch("src.remote_publish.EnvironmentManagerClient")
+    def test_publish_environment_error(self, mock_client_cls, capfd):
+        # Arrange
+        mock_config = MagicMock()
+        mock_client = mock_client_cls.return_value
+        mock_client.remote_publish_environment.side_effect = Exception("API error")
+
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            publish_environment(mock_config, True)
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert "Error in environment publish request" in out
+        assert "API error" in out
+
+    def test_write_slug_to_github_env(self):
+        # Arrange
+        gh_env_path = "path/to/github/env"
+        env_slug = "test-slug"
+        mock_file = mock_open()
+
+        # Act
+        with patch("builtins.open", mock_file):
+            write_slug_to_github_env(gh_env_path, env_slug)
+
+        # Assert
+        mock_file.assert_called_once_with(gh_env_path, "a", encoding="utf-8")
+        mock_file().write.assert_called_once_with(f"ENV_SLUG={env_slug}\n")
+
+    @patch("src.remote_publish.load_environment_config")
+    @patch("src.remote_publish.publish_environment")
+    @patch("src.remote_publish.write_slug_to_github_env")
+    def test_main_success(self, mock_write, mock_publish, mock_load, setup_env_vars):
+        # Arrange
+        mock_config = MagicMock()
+        mock_load.return_value = mock_config
+        mock_publish.return_value = "test-slug"
+
+        # Act
+        main()
+
+        # Assert
+        mock_load.assert_called_once_with("path/to/test/config.yaml")
+        mock_publish.assert_called_once_with(mock_config, False)
+        mock_write.assert_called_once_with("path/to/github/env", "test-slug")
+
+    @patch("os.getenv", return_value="")
+    def test_main_missing_config_path(self, mock_getenv, capfd):
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            main()
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert "ENV_CONFIG_PATH environment variable not set" in out

--- a/tests/test_wait_for_completion.py
+++ b/tests/test_wait_for_completion.py
@@ -1,0 +1,93 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src directory to path to import modules
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.wait_for_completion import main, wait_for_environment_publish
+
+
+class TestWaitForCompletion:
+
+    def test_wait_for_environment_publish_success(self):
+        # Arrange
+        mock_client = MagicMock()
+        mock_client.wait_for_env_remote_publish.return_value = True
+        env_slug = "test-env-slug"
+
+        # Act
+        result = wait_for_environment_publish(mock_client, env_slug)
+
+        # Assert
+        mock_client.wait_for_env_remote_publish.assert_called_once_with(env_slug)
+        assert result is True
+
+    def test_wait_for_environment_publish_failure(self):
+        # Arrange
+        mock_client = MagicMock()
+        mock_client.wait_for_env_remote_publish.return_value = False
+        env_slug = "test-env-slug"
+
+        # Act
+        result = wait_for_environment_publish(mock_client, env_slug)
+
+        # Assert
+        mock_client.wait_for_env_remote_publish.assert_called_once_with(env_slug)
+        assert result is False
+
+    def test_wait_for_environment_publish_error(self, capfd):
+        # Arrange
+        mock_client = MagicMock()
+        mock_client.wait_for_env_remote_publish.side_effect = Exception("API error")
+        env_slug = "test-env-slug"
+
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            wait_for_environment_publish(mock_client, env_slug)
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert "Error in environment publish request" in out
+        assert "API error" in out
+
+    @patch("src.wait_for_completion.EnvironmentManagerClient")
+    @patch("src.wait_for_completion.wait_for_environment_publish")
+    def test_main_success(self, mock_wait, mock_client_cls, setup_env_vars):
+        # Arrange
+        mock_client = mock_client_cls.return_value
+        mock_wait.return_value = True
+
+        # Act
+        with patch("sys.exit") as mock_exit:
+            main()
+
+        # Assert
+        mock_wait.assert_called_once_with(mock_client, "test-env-slug")
+        mock_exit.assert_called_once_with(0)
+
+    @patch("src.wait_for_completion.EnvironmentManagerClient")
+    @patch("src.wait_for_completion.wait_for_environment_publish")
+    def test_main_failure(self, mock_wait, mock_client_cls, setup_env_vars):
+        # Arrange
+        mock_client = mock_client_cls.return_value
+        mock_wait.return_value = False
+
+        # Act
+        with patch("sys.exit") as mock_exit:
+            main()
+
+        # Assert
+        mock_wait.assert_called_once_with(mock_client, "test-env-slug")
+        mock_exit.assert_called_once_with(1)
+
+    @patch("os.getenv", return_value="")
+    def test_main_missing_env_slug(self, mock_getenv, capfd):
+        # Act/Assert
+        with pytest.raises(SystemExit):
+            main()
+
+        # Check error message
+        out, _ = capfd.readouterr()
+        assert "ENV_SLUG environment variable not set" in out


### PR DESCRIPTION
## Summary 

* Added a new GitHub Actions workflow (`.github/workflows/test.yml`) to test Python scripts. Checks code formatting with `black` and `isort` and runs tests using `pytest`.
* Introduced `pytest` fixtures in `conftest.py` to mock environment configurations and manage environment variables during tests.
* Added unit tests for `src/remote_publish.py` and `src/wait_for_completion.py` 
* Updated the title in `README.md` to include the qBraid icon 